### PR TITLE
Fix InvalidValueError at the beginning  

### DIFF
--- a/src/components/GMaps/GMapsCoffee.jsx
+++ b/src/components/GMaps/GMapsCoffee.jsx
@@ -126,6 +126,12 @@ export default class GMaps extends Component{
   render() {
     // check current location which has fetched by res
     console.log('location is', this.state.location)
+
+    // render empty if not ready
+    if (!this.state.location.lat) {
+      return false;
+    }
+    
     return(
       <div>
         <Menus className={"BurgerMenu"} />


### PR DESCRIPTION
Fixed following error.

```
InvalidValueError: setCenter: not a LatLng or LatLngLiteral: in property lat: not a number
```

This is caused by rendering the map with invalid `location`, which will be set by `getUserLocation()()` asynchnously.

It would be great to show something to indicate it is now loading instead of this empty view.